### PR TITLE
Allow to use slot alias

### DIFF
--- a/src/matcher/templateIntentMatcher.js
+++ b/src/matcher/templateIntentMatcher.js
@@ -26,19 +26,19 @@ export default class TemplateIntentMatcher extends IntentMatcher {
             if(userOptions.includes(k)) { this.options[k] = true }
           })
         }
-        this.templates = this._generateTemplates(config["patterns"]);
+        this.templates = this._generateTemplates(config["patterns"], (config["slotAlias"] || {}));
     }
 
-    _generateTemplates(patterns) {
+    _generateTemplates(patterns, slotAliasMap) {
         const templates = [];
         for (const pattern of patterns) {
-            templates.push(this._generateTemplate(pattern));
+            templates.push(this._generateTemplate(pattern, slotAliasMap));
         }
         return templates;
     }
 
-    _generateTemplate(pattern) {
-        const results = this._extractElements(pattern);
+    _generateTemplate(pattern, slotAliasMap) {
+        const results = this._extractElements(pattern, slotAliasMap);
         let elements = results.elements;
         if (this.options.exactMatch) {
           elements = ['^']
@@ -55,7 +55,7 @@ export default class TemplateIntentMatcher extends IntentMatcher {
       return new Template(elements, slotNames);
     }
 
-    _extractElements(pattern) {
+    _extractElements(pattern, slotAliasMap) {
         let startPosition = 0;
         let endPosition = 0;
         const elements = [];
@@ -73,8 +73,9 @@ export default class TemplateIntentMatcher extends IntentMatcher {
             } else { // found slot
                 endPosition = pattern.indexOf("}", startPosition);
                 const slotName = pattern.substring(startPosition + 1, endPosition);
-                elements.push(`(${this.slot[slotName].join("|")})`);
-                slotNames.push(slotName);
+                const concreteSlotName = slotAliasMap[slotName] || slotName;
+                elements.push(`(${this.slot[concreteSlotName].join("|")})`);
+                slotNames.push(concreteSlotName);
                 inBrace = false;
             }
 

--- a/src/matcher/templateIntentMatcher.js
+++ b/src/matcher/templateIntentMatcher.js
@@ -74,8 +74,11 @@ export default class TemplateIntentMatcher extends IntentMatcher {
                 endPosition = pattern.indexOf("}", startPosition);
                 const slotName = pattern.substring(startPosition + 1, endPosition);
                 const concreteSlotName = slotAliasMap[slotName] || slotName;
+                if (!this.slot[concreteSlotName]) {
+                  throw new Error(`Not Found SlotName: '${concreteSlotName}'`)
+                }
                 elements.push(`(${this.slot[concreteSlotName].join("|")})`);
-                slotNames.push(concreteSlotName);
+                slotNames.push(slotName);
                 inBrace = false;
             }
 

--- a/test/templateMatcher.test.js
+++ b/test/templateMatcher.test.js
@@ -118,4 +118,22 @@ describe( 'TemplateMatcher.match', () => {
             assert( result["match"] === "Search with ingredients" );
         });
     });
+
+    describe( '#match with SlotAlias', () => {
+        it( 'returns true when input includes slot alias match the registered patterns', () => {
+            const config = new ConfigurationBuilder()
+                .addIntent("Search with ingredients", {
+                    "type" : "template",
+                    "patterns" : [ "#{shokuzai}でできるレシピおしえて" ],
+                    "slotAlias": { shokuzai: 'ingredients' },
+                })
+                .addSlot("ingredients", ["じゃがいも", "ナス"])
+                .build();
+            const input = {"text" : "ナスでできるレシピおしえて"};
+            const handler = new IntentHandler(config.intent(0), config.slots());
+            const result = handler.match(input);
+            assert( input['feature']['shokuzai'] === 'ナス' );
+            assert( result === true );
+        });
+    });
 });


### PR DESCRIPTION
Alexa can use any names for one slot `type` (e.g. Ingredients).
On the other hand, Satori does not treat slots as types.
I want to use alias for slot to adjust this miss match.

@takahi-i 